### PR TITLE
Fix production build.

### DIFF
--- a/src/build/webpack-config-build.js
+++ b/src/build/webpack-config-build.js
@@ -4,7 +4,8 @@ const TypedocWebpackPlugin = require('typedoc-webpack-plugin')
 
 module.exports = function () {
   return {
-    mode: 'development',
+    mode: 'production',
+    devtool: 'devtool',
     entry: {
       app: config.FOLDERS.SRC + '/index.ts',
     },


### PR DESCRIPTION
Now production build is 10kb.
Also, this fix removes all eval methods from the built file.

![image](https://user-images.githubusercontent.com/23530004/120524035-448ac300-c3df-11eb-9276-d7991f9eee1f.png)

This pr is required for https://github.com/epicmaxco/vuestic-ui/issues/821
